### PR TITLE
Fix zk-luhmann-id sorting

### DIFF
--- a/my-lisp/zk-luhmann.el
+++ b/my-lisp/zk-luhmann.el
@@ -45,6 +45,11 @@
 
 ;;; Luhmann ID Support
 
+(defcustom zk-luhmann-id-format "{\\([0-9a-zA-Z,]*\\)}"
+  "Default format for candidates in the index."
+    :group 'zk-luhmann
+    :type 'string)
+
 (defun zk-luhmann ()
   "Find note with Luhmann-IDs."
   (interactive)
@@ -79,10 +84,10 @@
   (sort list
         (lambda (a b)
           (let ((one
-                 (when (string-match "{\\([^ ]*\\)" a)
+                 (when (string-match zk-luhmann-id-format a)
                    (match-string 1 a)))
                 (two
-                 (when (string-match "{\\([^ ]*\\)" b)
+                 (when (string-match zk-luhmann-id-format b)
                    (match-string 1 b))))
             (string< one two)))))
 

--- a/my-lisp/zk-luhmann.el
+++ b/my-lisp/zk-luhmann.el
@@ -59,7 +59,7 @@
   :type 'string
   :group 'zk-luhmann)
 
-(setq zk-luhmann-id-regex (concat zk-luhmann-id-start-char "\\([0-9a-zA-Z,]*\\)" zk-luhmann-id-stop-char))
+(setq zk-luhmann-id-regexp (concat zk-luhmann-id-start-char "\\([0-9a-zA-Z,]*\\)" zk-luhmann-id-stop-char))
 
 (defun zk-luhmann ()
   "Find note with Luhmann-IDs."
@@ -116,7 +116,7 @@
 
 (defun zk-luhmann-files ()
   "List notes with Luhmann-IDs."
-  (zk--directory-files t zk-luhmann-id-start-char))
+  (zk--directory-files t (concat zk-id-regexp "\s" zk-luhmann-id-regexp)))
 
 (defun zk-luhmann-format-candidates (&optional files)
   "Format completions candidates for FILES with Luhmann-IDs."

--- a/my-lisp/zk-luhmann.el
+++ b/my-lisp/zk-luhmann.el
@@ -224,7 +224,7 @@
             (zk-index (zk--directory-files t id)
                       zk-index-last-format-function
                       #'zk-luhmann-sort))
-          (t (progn (zk-index (zk--directory-files t (concat sub-id " \\|" sub-id zk-luhmann-id-delimite ".[^" zk-luhmann-id-stop-char "]*"))
+          (t (progn (zk-index (zk--directory-files t (concat sub-id " \\|" sub-id zk-luhmann-id-delimiter ".[^" zk-luhmann-id-stop-char "]*"))
                        zk-index-last-format-function
                        #'zk-luhmann-sort)
                     (re-search-forward id nil t)
@@ -260,79 +260,6 @@
     (zk-index files
               zk-index-last-format-function
               #'zk-luhmann-sort)))
-
-;; (defun zk-luhmann-index-level (arg)
-;;   (interactive)
-;;   (let* ((arg (if current-prefix-arg
-;;                    (- current-prefix-arg 1)
-;;                 arg))
-;;          (base-rx "{[0-9]*")
-;;          (slug ",.")
-;;          (new-slug "")
-;;          (regexp
-;;           (progn
-;;             (when arg
-;;               (dotimes (_ arg)
-;;                 (setq new-slug (concat new-slug slug))))
-;;             (concat base-rx new-slug " ")))
-;;          (current-files (zk--parse-id 'file-path (zk-index--current-id-list)))
-;;          (files (remq nil
-;;                       (mapcar
-;;                        (lambda (x)
-;;                          (when (member x (zk--directory-files t regexp))
-;;                            x))
-;;                        current-files))))
-;;     (zk-index files
-;;               zk-index-last-format-function
-;;               #'zk-luhmann-sort)))
-
-;; old forward and back
-;; (defun zk-luhmann-index-forward ()
-;;   "Focus on notes that share a particular ID string.
-;; Calling this function on note \"{4,3 }\" will present a listing
-;; of all notes whose Luhmann-IDs begin with \"4,3\", such as
-;; \"{4,3,a }\" and \"{4,3,c,1,d }\". The effect is like descending
-;; \"into\" the archive.
-
-;; Keep in mind that this function will exclude notes that might be
-;; considered \"adjacent\", in the sense that \"{4,4 }\" is
-;; \"adjacent\" to \"{4,3 }\". This function is therefore a
-;; convenience feature, not a substitute for thinking.
-
-;; See 'zk-luhmann-index-back' for complementary behavior."
-;;   (interactive)
-;;   (let* ((line-count (count-lines (point-min)
-;;                                   (point-max)))
-;;          (regexp
-;;           (cond ((eq this-command 'zk-luhmann-index-forward)
-;;                  "{.[^ }]*")
-;;                 ((eq this-command 'zk-luhmann-index-back)
-;;                  "{.[^, }]*")))
-;;           (line (buffer-substring
-;;                  (line-beginning-position)
-;;                  (line-end-position)))
-;;           (id (unless (string= "" line)
-;;                 (progn
-;;                   (string-match regexp line)
-;;                   (match-string-no-properties 0 line)))))
-;;     (when id
-;;       (zk-index (zk--directory-files t id)
-;;                 zk-index-last-format-function
-;;                 #'zk-luhmann-sort))
-;;     (when (and (eq this-command 'zk-luhmann-index-back)
-;;                (eq line-count (count-lines (point-min)
-;;                                            (point-max))))
-;;       (zk-luhmann-index-top))))
-
-;; (defun zk-luhmann-index-back ()
-;;   "Focus on notes that share all but the last ID element.
-;; Calling this function on \"{4,3,a }\ will present a listing of
-;; all notes whose Luhmann IDs begin with \"4,3\". The effect is
-;; like returning back toward the \"top\" of the archive.
-
-;; See 'zk-luhmann-index-forward' for complementary behavior."
-;;   (interactive)
-;;   (zk-luhmann-index-forward))
 
 (provide 'zk-luhmann)
 ;;; zk-luhmann.el ends here


### PR DESCRIPTION
Dear Grant, 

first of all thanks for providing `zk`. While working with this package, I stumbled over an issue with the sorting of the "Luhmann IDs". Previously, the IDs needed to include a space before the closing brace, which is fixed with the modification of the regex to match the Luhmann ID. In order to do this and stay customizable, I introduced `zk-luhmann-id-format` via `defcustom`

Even though that this is not "the officially packaged" `zk`, I thought I "upstream" this modification to you. 
Thanks again for `zk`. 

Best regards,
jgru